### PR TITLE
API endpoint protected by Bearer token authorization

### DIFF
--- a/TEStribute/config/server_config.yaml
+++ b/TEStribute/config/server_config.yaml
@@ -4,6 +4,24 @@ server:
     port: 8080
     debug: True
 
+# Security settings
+security:
+    authorization_required: True
+    jwt:
+        auth_header_key: Authorization
+        claim_identity: sub
+        claim_issuer: iss
+        claim_key_id: kid
+        decode_algorithms:
+          - RS256
+        idp_config_jwks: jwks_uri
+        idp_config_url_suffix: /.well-known/openid-configuration
+        idp_config_userinfo: userinfo_endpoint
+        jwt_prefix: Bearer
+        validation_methods:
+          - userinfo
+          - public_key
+
 # OpenAPI specs
 openapi:
     TEStribute: specs/schema.TEStribute.openapi.yaml

--- a/TEStribute/config/server_config.yaml
+++ b/TEStribute/config/server_config.yaml
@@ -6,7 +6,7 @@ server:
 
 # Security settings
 security:
-    authorization_required: True
+    authorization_required: False
     jwt:
         auth_header_key: Authorization
         claim_identity: sub
@@ -18,7 +18,7 @@ security:
         idp_config_url_suffix: /.well-known/openid-configuration
         idp_config_userinfo: userinfo_endpoint
         jwt_prefix: Bearer
-        validation_methods:
+        validation_methods:  # available methods: 'userinfo', 'public_key'
           - userinfo
           - public_key
 

--- a/TEStribute/controllers/rank_services.py
+++ b/TEStribute/controllers/rank_services.py
@@ -1,11 +1,12 @@
 import json
 
-from werkzeug.exceptions import (BadRequest, InternalServerError)
+from werkzeug.exceptions import (BadRequest, InternalServerError, Unauthorized)
 
 from TEStribute import rank_services
+from TEStribute.decorators import auth_token_optional
 from TEStribute.errors import (ResourceUnavailableError, ValidationError)
 
-
+@auth_token_optional
 def RankServices(body):
 
     ranked_response = __post_rank_services(body)
@@ -30,6 +31,8 @@ def __post_rank_services(params):
         raise BadRequest(e.args) from e
     except ResourceUnavailableError as e:
         raise BadRequest(e.args) from e
+    except Unauthorized as e:
+        raise Unauthorized(e.args) from e
     except Exception as e:
         raise InternalServerError(e.args) from e
 

--- a/TEStribute/controllers/rank_services.py
+++ b/TEStribute/controllers/rank_services.py
@@ -7,9 +7,9 @@ from TEStribute.decorators import auth_token_optional
 from TEStribute.errors import (ResourceUnavailableError, ValidationError)
 
 @auth_token_optional
-def RankServices(body):
+def RankServices(body, *args, **kwargs):
 
-    ranked_response = __post_rank_services(body)
+    ranked_response = __post_rank_services(params=body)
 
     # TODO:
     #   handle FileNotFoundError

--- a/TEStribute/decorators.py
+++ b/TEStribute/decorators.py
@@ -1,0 +1,47 @@
+"""Custom decorators."""
+
+from connexion import request
+from flask import current_app
+from functools import wraps
+import logging
+from typing import Callable
+
+from werkzeug.exceptions import Unauthorized
+
+from TEStribute.security.process_jwt import JWT
+
+logger = logging.getLogger("TEStribute")
+
+
+def auth_token_optional(fn: Callable) -> Callable:
+    """
+    The decorator protects an endpoint from being called without a valid
+    authorization token.
+    """
+    @wraps(fn)
+    def wrapper(*args, **kwargs):
+
+        # Check if authentication is enabled
+        if current_app.config["security"]["authorization_required"]:
+
+            try:
+                jwt = JWT(request=request)
+                jwt.validate()
+                jwt.get_user()
+            except Exception as e:
+                raise Unauthorized(e.args) from e
+
+            # Return wrapped function with token data
+            return fn(
+                jwt=jwt.jwt,
+                claims=jwt.claims,
+                user_id=jwt.user,
+                *args,
+                **kwargs
+            )
+
+        # Return wrapped function without token data
+        else:
+            return fn(*args, **kwargs)
+
+    return wrapper

--- a/TEStribute/errors.py
+++ b/TEStribute/errors.py
@@ -5,10 +5,10 @@ with a Connexion app instance.
 import logging
 
 from connexion import App
-from connexion.exceptions import ExtraParameterProblem
+from connexion.exceptions import (ExtraParameterProblem)
 from flask import Response
 from json import dumps
-from werkzeug.exceptions import (BadRequest, InternalServerError)
+from werkzeug.exceptions import (BadRequest, InternalServerError, Unauthorized)
 
 logger = logging.getLogger("TEStribute")
 
@@ -19,6 +19,7 @@ def register_error_handlers(app: App) -> App:
     app.add_error_handler(BadRequest, handle_bad_request)
     app.add_error_handler(ExtraParameterProblem, handle_bad_request)
     app.add_error_handler(InternalServerError, handle_internal_server_error)
+    app.add_error_handler(Unauthorized, handle_unauthorized)
     logger.info('Registered custom error handlers with Connexion app.')
 
     # Workaround for adding a custom handler for `connexion.problem` responses
@@ -83,7 +84,7 @@ def handle_bad_request(exception: BadRequest) -> Response:
             }],
             'message': "The request could not be processed.",
         }),
-        status=400,
+        status=int(exception.code),
         mimetype="application/problem+json",
     )
 
@@ -97,4 +98,20 @@ def handle_internal_server_error(exception: Exception) -> Response:
             }),
         status=500,
         mimetype="application/problem+json",
+    )
+
+def handle_unauthorized(exception: Unauthorized) -> Response:
+    return Response(
+        response=dumps({
+            'code': int(exception.code),
+            'errors': [{
+                'reason': str(exception.__class__).split("'")[1],
+                'message': [
+                    exception.description,
+                ],
+            }],
+            'message': "The request is unauthorized.",
+        }),
+        status=int(exception.code),
+        mimetype="application/problem+json"
     )

--- a/TEStribute/errors.py
+++ b/TEStribute/errors.py
@@ -5,7 +5,7 @@ with a Connexion app instance.
 import logging
 
 from connexion import App
-from connexion.exceptions import (ExtraParameterProblem)
+from connexion.exceptions import ExtraParameterProblem
 from flask import Response
 from json import dumps
 from werkzeug.exceptions import (BadRequest, InternalServerError, Unauthorized)
@@ -27,7 +27,7 @@ def register_error_handlers(app: App) -> App:
     # cannot be intercepted by `add_error_handler`; see here:
     # https://github.com/zalando/connexion/issues/138
     @app.app.after_request
-    def _rewrite_bad_request(response):
+    def _rewrite_bad_request(response: Response) -> Response:
         if (
             response.status_code == 400 and
             response.data.decode('utf-8').find('"title":') is not None and
@@ -35,7 +35,7 @@ def register_error_handlers(app: App) -> App:
         ):
             response = handle_bad_request_validation(response)
         return response
-    
+
     return app
 
 

--- a/TEStribute/security/process_jwt.py
+++ b/TEStribute/security/process_jwt.py
@@ -1,0 +1,424 @@
+"""
+Classes and functions for dealing with the processing of JSON Web Tokens (JWTs).
+"""
+from enum import Enum
+from functools import partial
+import json
+from os import get_inheritable
+import requests
+from simplejson.errors import JSONDecodeError
+from typing import (Dict, List, Union)
+
+from jwt import (decode, get_unverified_header, algorithms)
+
+
+class JWT:
+    """
+    Class that extracts JSON Web Tokens (JWT) and related information from a 
+    HTTP request and validates the JWT via one or more methods.
+    """
+
+    # Class attributes (can be updated through JWT.config(**kwargs))
+    auth_header_key: str = "Authorization"
+    claim_identity: str = "sub"
+    claim_issuer: str = "iss"
+    claim_key_id: str = "kid"
+    decode_algorithms: List[str] = ["RS256"]
+    idp_config_jwks: str = "jwks_uri"
+    idp_config_url_suffix: str = "/.well-known/openid-configuration"
+    idp_config_userinfo: str = "userinfo_endpoint"
+    jwt_prefix: str = "Bearer"
+    validation_methods: List[str] = ["userinfo", "public_key"]
+
+
+    # Class methods
+    @classmethod
+    def config(cls, **kwargs) -> None:
+        for k, v in kwargs.items():
+            setattr(cls, k, v)
+
+
+    # Constructors
+    def __init__(
+        self, 
+        jwt: Union[None, str] = None,
+        request: Union[None, requests.models.Request] = None,
+        user: str = "",
+        claims: Dict = {},
+        header_claims: Dict = {},
+        idp_config: Dict = {},
+        public_keys: Dict = {},
+        current_key: str = "",
+    ) -> None:
+        """
+#        Constructs JWT class instance by parsing the JWT from a HTTP request 
+#        header.
+#
+#        :param request: HTTP request. Instance of `requests.models.Request`.
+#        :param header_key: Key/name of header item that contains the JWT.
+#        :param prefix: Prefix separated from JWT by whitespace, e.g., "Bearer".
+#
+#        :return: JWT.
+#
+#        :raises AttributeError: Argument to `request` is not of the expected
+#                type.
+#        :raises KeyError: No header with specified name available.
+#        :raises ValueError: Value of authentication header does not contain
+#                prefix.
+#        :raises ValueError: Value of authentication header has wrong prefix.
+        """
+        # JWT not passed and cannot be extracted
+        if jwt is None and request is None:
+            raise ValueError(
+                "Either a JWT or a request object with a header containg a " \
+                "JWT needs to be passed to the constructor."
+            )
+
+        # Extract JWT from header
+        if jwt is None:
+
+            # Get authorization header
+            try:
+                auth_header = request.headers.get(self.auth_header_key, None)
+            except AttributeError:
+                raise AttributeError(
+                    "Agument passed to parameter 'request' does not look loke a " \
+                    "valid HTTP request."
+                )
+
+            if auth_header is None:
+                raise KeyError(
+                    f"No HTTP header with name '{self.auth_header_key}' found."
+                )
+
+            # Ensure that authorization header contains prefix
+            try:
+                (found_prefix, jwt) = auth_header.split()
+            except ValueError:
+                raise ValueError(
+                    "Authentication header is malformed, prefix and JWT expected."
+                )
+
+            # Ensure that prefix is correct
+            if found_prefix != self.jwt_prefix:
+                raise ValueError(
+                    f"Expected JWT prefix '{self.jwt_prefix}' in authentication " \
+                    f"header, but found '{found_prefix}' instead."
+                )
+
+        # Initialize instance
+        self.jwt = jwt
+        self.user = user 
+        self.claims = claims
+        self.header_claims = header_claims
+        self.idp_config = idp_config
+        self.public_keys = public_keys
+        self.current_key = current_key
+
+
+    # Other methods
+    def get_claims(
+        self,
+        force: bool=False,
+    ) -> None:
+        """
+#
+        """
+        if not self.claims or force:
+            try:
+                self.claims = decode(
+                    jwt=self.jwt,
+                    verify=False,
+                    algorithms=self.decode_algorithms,
+                )
+            except Exception as e:
+                raise Exception(
+                    f"JWT could not be decoded. Original error message: " \
+                    f"{type(e).__name__}: {e}"
+                ) from e
+
+
+    def get_header_claims(
+        self,
+        force: bool=False,
+    ) -> None:
+        """
+#
+        """
+        if not self.header_claims or force:
+            try:
+                self.header_claims = get_unverified_header(self.jwt)
+            except Exception as e:
+                raise Exception(
+                    f"Could not extract JWT header claims. Original error " \
+                    f"message: {type(e).__name__}: {e}"
+                ) from e
+
+
+    def get_idp_config(
+        self,
+        force: bool = False,
+    ) -> None:
+        """
+#        Retrieves an OpenID Connect (OIDC) identity provider's (IdP) service info 
+#        based on a JSON Web Token's (JWT) issuer claim.
+#
+#        :param issuer: JWT issuer claim and base URL for service info endpoint.
+#        :param suffix: URL suffix for IdP service info endpoint.
+#
+#        :returns: Dictionary of IdP service info/configuration.
+#
+#        :raises KeyError: Response is valid JSON but does not contain information
+#                required by OIDC standard.
+#        :raises requests.exceptions.ConnectionError: Not very well defined.
+#        :raises requests.exceptions.HTTPError: Not very well defined.
+#        :raises requests.exceptions.MissingSchema: Compiled URL cannot be
+#                interpreted as URL.
+#        :raises TypeError: Response is not valid JSON.
+        """
+        if not self.idp_config or force:
+
+            # Get claims unless present
+            try:
+                self.get_claims(force=force)
+            except Exception:
+                raise
+
+            # Build endpoint URL
+            try:
+                root = self.claims[self.claim_issuer].rstrip('/')
+            except KeyError as e:
+                raise KeyError(
+                    f"Issuer '{self.claim_issuer}' is not available. " \
+                    f"Original error message: {type(e).__name__}: {e}"
+                ) from e
+            url = f"{root}/{self.idp_config_url_suffix}"
+
+            # Send GET request to OIDC service info/config endpoint
+            try:
+                response = requests.get(url)
+                response.raise_for_status()
+            except requests.exceptions.MissingSchema as e:
+                raise requests.exceptions.MissingSchema(
+                    f"Value '{url} could not be interpreted as URL."
+                ) from e
+            except requests.exceptions.ConnectionError:
+                raise
+            except requests.exceptions.HTTPError:
+                raise
+
+            # Convert JSON response to dictionary
+            try:
+                response = response.json()
+            except JSONDecodeError as e:
+                raise TypeError(
+                    "The response does not look like valid JSON."
+                ) from e
+
+            # Set IdP config
+            self.idp_config = response
+
+
+    def get_public_keys(
+        self,
+        force: bool = False,
+    ) -> None:
+        """
+        Obtain the identity provider's list of public keys.
+        """
+        if not self.public_keys or force:
+
+            # Get IdP config
+            try:
+                self.get_idp_config(force=force)
+            except Exception:
+                raise
+
+            # Get JWK set URL
+            try:
+                url = self.idp_config[self.idp_config_jwks]
+            except KeyError as e:
+                raise KeyError (
+                    f"Field '{self.idp_config_jwks}' not available in " \
+                    f"identity provider's config. Original error message: " \
+                    f"{type(e).__name__}: {e}"
+                ) from e
+        
+            # Get JWK sets from identity provider
+            try:
+                response = requests.get(url)
+                response.raise_for_status()
+            except Exception as e:
+                raise Exception(
+                    f"Could not connect to endpoint '{url}'. Original error " \
+                    f"message: {type(e).__name__}: {e}"
+                ) from e
+
+            # Iterate over all JWK sets and store public keys
+            keys = {}
+            try:
+                for jwk in response.json()['keys']:
+                    keys[jwk[self.claim_key_id]] = algorithms.RSAAlgorithm.\
+                        from_jwk(json.dumps(jwk))
+            except KeyError as e:
+                raise KeyError(
+                    f"Public keys could not be processed. Original error " \
+                    f"message: {type(e).__name__}: {e}"
+                ) from e
+            self.public_keys = keys
+
+
+    def get_current_key(
+        self,
+        force: bool = False,
+    ) -> None:
+        """
+        
+        """
+        if not self.current_key or force:
+
+            # Get public keys
+            try:
+                self.get_public_keys(force=force)
+            except Exception:
+                raise
+
+            # Get JWT header claims 
+            try:
+                self.get_header_claims(force=force)
+            except Exception:
+                raise
+
+            # Get JWT key ID
+            try:
+                key_id_used = self.header_claims[self.claim_key_id]
+            except KeyError as e:
+                f"Key ID claim '{self.claim_key_id}' is not available in " \
+                f"JWT. Original error message: {type(e).__name__}: {e}"
+
+            # Set JWT public key 
+            try:
+                self.current_key = self.public_keys[key_id_used]
+            except KeyError as e:
+                raise KeyError(
+                    f"Key used in JWT not available in issuer's JWK sets. " \
+                    f"Original error message: {type(e).__name__}: {e}"
+                ) from e
+
+
+    def validate(
+        self,
+        force: bool = False,
+    ) -> None:
+        """
+        
+        """
+        if not len(self.validation_methods):
+            raise ValueError(
+                "No validation methods configured."
+            )
+        for method in self.validation_methods:
+            try:
+                ValidationMethods[method].value(self, force=force)
+            except Exception as e:
+                raise ValueError(
+                    f"Validation of JWT '{self.jwt}' by method " \
+                    f"'{method}' failed. Original error message: " \
+                    f"{type(e).__name__}: {e}"
+                ) from e
+
+
+    def get_user_info(
+        self,
+        force: bool = False,
+    ) -> None:
+        """
+        
+        """
+        # Get IdP config
+        try:
+            self.get_idp_config(force=force)
+        except Exception:
+            raise
+
+        # Get userinfo URL
+        try:
+            url = self.idp_config[self.idp_config_userinfo]
+        except KeyError as e:
+            raise KeyError (
+                f"Field '{self.idp_config_userinfo}' not available in " \
+                f"identity provider's config. Original error message: " \
+                f"{type(e).__name__}: {e}"
+            ) from e
+        
+        # Build headers
+        headers = {
+            f"{self.auth_header_key}": f"{self.jwt_prefix} {self.jwt}"
+        }
+
+        # Get user info
+        try:
+            response = requests.get(
+                url,
+                headers=headers,
+            )
+            response.raise_for_status()
+        except Exception:
+            raise
+        self.user_info = response
+
+    
+    def validate_signature(
+        self,
+        force: bool = False,
+        update_claims: bool = False,
+    ):
+        try:
+            self.get_current_key(force=force)
+        except Exception:
+            raise
+        
+        try:
+            response = decode(
+                jwt=self.jwt,
+                verify=True,
+                key=self.current_key,
+                algorithms=self.decode_algorithms,
+            )
+        except Exception as e:
+            raise Exception(
+                f"JWT could not be decoded. Original error message: " \
+                f"{type(e).__name__}: {e}"
+            ) from e
+        
+        if update_claims:
+            self.claims = response
+
+
+    def get_user(
+        self,
+        force: bool = False,
+    ):
+        """
+    
+        """
+        if not self.user or force:
+
+            # Get claims unless present
+            try:
+                self.get_claims(force=force)
+            except Exception:
+                raise
+
+            # Get user ID
+            try:
+                self.user = self.claims[self.claim_identity]
+            except KeyError as e:
+                f"Key ID claim '{self.claim_identity}' is not available in " \
+                f"JWT. Original error message: {type(e).__name__}: {e}"
+
+
+class ValidationMethods(Enum):
+    """Enumerator class for different JSON Web Token validation methods."""
+    userinfo = partial(JWT.get_user_info)
+    public_key = partial(JWT.validate_signature)

--- a/TEStribute/server.py
+++ b/TEStribute/server.py
@@ -2,11 +2,13 @@
 Service for the TEStribute.
 """
 import os
+from shutil import copyfile
 
 from connexion import App
 
 from TEStribute.config.parse_config import config_parser
 from TEStribute.errors import (register_error_handlers)
+from TEStribute.security.process_jwt import JWT
 
 # Instantiate app
 app = App(__name__)
@@ -35,13 +37,25 @@ def add_settings(app: App) -> App:
     app.host = config["server"]["host"]
     app.port = config["server"]["port"]
     app.debug = config["server"]["debug"]
+    app.app.config.update(config)
     return app
 
 
 def add_openapi(app: App) -> App:
     """Add OpenAPI specification to app instance"""
+    path = os.path.join(
+        os.path.abspath(
+            os.path.dirname(
+                os.path.realpath(__file__)
+            )
+        ),
+        config["openapi"]["TEStribute"]
+    )
+    if config["security"]["authorization_required"]:
+        path = add_security_definitions(in_file=path)
+        JWT.config(**config["security"]["jwt"])
     app.add_api(
-        config["openapi"]["TEStribute"],
+        path,
         validate_responses=True,
         strict_validation=True
     )
@@ -52,6 +66,35 @@ def main(app: App) -> None:
     """Initialize, configure and run server"""
     app = configure_app(app)
     app.run()
+
+
+def add_security_definitions(
+    in_file: str,
+    ext: str = 'security_definitions_added.yaml'
+) -> str:
+    """Adds 'securityDefinitions' section to OpenAPI YAML specs."""
+    # Set security definitions
+    amend = '''
+
+# Amended by WES-ELIXIR
+  securitySchemes:
+    jwt:
+      type: http
+      scheme: bearer
+      in: header
+      bearerFormat: JWT
+      description: "ffsfd"
+'''
+
+    # Create copy for modification
+    out_file: str = '.'.join([os.path.splitext(in_file)[0], ext])
+    copyfile(in_file, out_file)
+
+    # Append security definitions
+    with open(out_file, 'a') as mod:
+        mod.write(amend)
+
+    return out_file
 
 
 if __name__ == "__main__":

--- a/TEStribute/server.py
+++ b/TEStribute/server.py
@@ -81,9 +81,11 @@ def add_security_definitions(
     jwt:
       type: http
       scheme: bearer
-      in: header
       bearerFormat: JWT
-      description: "ffsfd"
+      x-bearerInfoFunc: security.process_jwt.connexion_bearer_info
+
+security:
+- jwt: []
 '''
 
     # Create copy for modification

--- a/TEStribute/specs/schema.TEStribute.openapi.security_definitions_added.yaml
+++ b/TEStribute/specs/schema.TEStribute.openapi.security_definitions_added.yaml
@@ -342,3 +342,13 @@ components:
       items:
         type: string
         format: uri
+
+
+# Amended by WES-ELIXIR
+  securitySchemes:
+    jwt:
+      type: http
+      scheme: bearer
+      in: header
+      bearerFormat: JWT
+      description: "ffsfd"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 addict==2.2.0
+asn1crypto==0.24.0
 astroid==2.2.5
 atomicwrites==1.3.0
 attrs==19.1.0
@@ -8,12 +9,14 @@ bleach==3.1.0
 bravado==10.4.1
 bravado-core==5.13.1
 certifi==2019.6.16
+cffi==1.12.3
 chardet==3.0.4
 Click==7.0
 clickclick==1.2.2
 connexion==2.3.0
 constantly==15.1.0
 crochet==1.10.0
+cryptography==2.7
 cssselect==1.0.3
 decorator==4.4.0
 dicttoxml==1.7.4
@@ -54,6 +57,7 @@ pkginfo==1.5.0.1
 pluggy==0.12.0
 py==1.8.0
 pycodestyle==2.5.0
+pycparser==2.19
 Pygments==2.4.2
 PyHamcrest==1.9.0
 PyJWT==1.6.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -56,6 +56,7 @@ py==1.8.0
 pycodestyle==2.5.0
 Pygments==2.4.2
 PyHamcrest==1.9.0
+PyJWT==1.6.4
 pylint==2.3.1
 pyparsing==2.4.1.1
 pyquery==1.4.0


### PR DESCRIPTION
- Section `security` added to [`pro_tes/config/server_config.yaml`](pro_tes/config/server_config.yaml)
- Config parameter `security: authorization_required` can be used to switch on/off authorization
- If `security: authorization_required` is set to `true`, the OpenAPI-compliant sections `securitySchemes` (in section `components`) and `security` (in root) are added to the [specs](pro_tes/specs/schema.TEStribute.openapi.yaml), leading to a button "Authorization" being displayed on Swagger UI
- Clicking the "Authorization" button allows the user to paste a JSON Web Token (JWT), which is then automatically added as header field `Authorization: Bearer <JWT>` to every request submitted via Swagger UI
- The decorator `@auth_token_optional` (defined in [`pro_tes/decorators.py`](pro_tes/decorators.py)), now added to the definition of API endpoint `POST /rank_services`, leads to the provided JWT being parsed from the header, decoded and optionally validated
- Validation may occur via one or both of the methods `userinfo` (call to IdP `/userinfo` endpoint) or `public_key` (signature validated via IdP's public key for that JWT) and can be configured via the config array `security: jwt: validation_methods`
- JWT parsing, decoding and validation are implemented via the `JWT` class defined in [`pro_tes/security/process_jwt.py`](pro_tes/security/process_jwt.py)
- Any error occurring during JWT processing (parsing, decoding, validation) leads to a `401/Unauthorized` error being raised and handled by an error handler defined in [`pro_tes/errors.py`](pro_tes/errors.py)
- The `securitySchemes` section in the modified specs further includes a field `x-bearerInfoFunc`, which is mandated by `connexion>=2.0` and points to a function which is required to accept a token and return a dictionary that includes the key `scope` (see [documentation](https://connexion.readthedocs.io/en/latest/security.html))
- `x-bearerInfoFunc` points to function [`pro_tes.security.process_jwt.connexion_bearer_info()`](pro_tes/security/process_jwt.py) which decodes the token and adds an empty string to key `scope` of the resulting dictionary, thus preventing Connexion from raising a hard-to-catch (and somewhat unwarranted) `OAuthProblem/Unauthorized` exception itself (thanks, Zalando!)

Closes #34