### PR TITLE
Implemented object consistency checks

### DIFF
--- a/TEStribute/models/response.py
+++ b/TEStribute/models/response.py
@@ -3,9 +3,9 @@ Object models for representing nested, dependent data structures.
 """
 # TODO: Rename 'costs_total' to 'costs_compute'
 # TODO: Rename 'drs_ids' to 'object_ids'
+# TODO: Rename "time"/"times" to "duration"?
 # TODO: Implement changes suggested by Susheel
 # TODO: Implement "smart" filter for service combinations
-# TODO: Handle currencies and conversions
 from copy import deepcopy
 from itertools import product
 import logging


### PR DESCRIPTION
Input objects are now checked for consistency with regard to sizes and checksums across different DRS instances. This is to enforce the out-of-spec assumption in `TEStribute` that object IDs across different DRS instances unambiguously point to identical files.

Closes #38