### PR TITLE
Minor refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Ensure you have the following software installed:
 Clone repository and start Docker service
 
 ```bash
-git clone https://github.com/elixir-europe/proTES.git app
+git clone https://github.com/elixir-europe/TEStribute.git app
 cd app
 docker-compose up --build --detach
 ```

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,6 @@ setup(
         'ga4gh tes elixir rest api app openapi python'
         'task distribution'
     ),
-    keywords=(),
     classifiers=[
         "License :: OSI Approved :: Apache Software License",
         "Development Status :: 3 - Alpha",


### PR DESCRIPTION
Fixed a couple of typos in `setup.py` and `README.md` files.
In setup.py `keywords=()` was used twice which was causing
docker-compose to fail to bring up the cluster.