### PR TITLE
add test coverage service badge to docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,6 @@ python:
   - "3.7"
   - "3.8"
 
-services:
-  - docker
-
 if: type != pull_request  # do not build anything for PRs
 
 install:
@@ -19,8 +16,11 @@ script:
   - mypy TEStribute setup.py --ignore-missing-imports
   - flake8 TEStribute setup.py
   - pytest --disable-warnings
+  - coverage run --source TEStribute -m pytest
+  - coveralls
 
 matrix:
+  fast_finish: true
   allow_failures:
     - python: "3.8"
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # TEStribute
 
-[![Apache License](https://img.shields.io/badge/license-Apache%202.0-orange.svg?style=flat&color=important)](http://www.apache.org/licenses/LICENSE-2.0)
-[![Build Status](https://travis-ci.com/elixir-cloud-aai/TEStribute.svg?branch=dev)](https://travis-ci.com/elixir-cloud-aai/TEStribute)
+[![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0)
+[![Python_versions](https://img.shields.io/pypi/pyversions/TEStribute.svg?style=flat)](https://pypi.python.org/pypi/TEStribute)
+[![Build_status](https://travis-ci.com/elixir-cloud-aai/TEStribute.svg?branch=dev)](https://travis-ci.com/elixir-cloud-aai/TEStribute)
 [![Website](https://img.shields.io/website?url=http%3A%2F%2Ftestribute.c03.k8s-popup.csc.fi%2Fui%2F)](http://testribute.c03.k8s-popup.csc.fi/ui/)
-[![GitHub: latest tag](https://flat.badgen.net/github/tag/elixir-cloud-aai/TEStribute?color=cyan&icon=github)](https://github.com/elixir-cloud-aai/TEStribute/releases)
-[![PyPI](https://img.shields.io/pypi/pyversions/TEStribute.svg?style=flat)](https://pypi.python.org/pypi/TEStribute)
-[![PyPI](https://img.shields.io/pypi/v/TEStribute.svg?style=flat&color=bright-green)](https://pypi.python.org/pypi/TEStribute)
+[![GitHub_tag](https://img.shields.io/github/v/tag/elixir-cloud-aai/TEStribute?color=C39BD3)](https://github.com/elixir-cloud-aai/TEStribute/releases)
+[![PyPI_release](https://img.shields.io/pypi/v/TEStribute.svg?style=flat&color=C39BD3)](https://pypi.python.org/pypi/TEStribute)
+[![Coverage](https://img.shields.io/coveralls/github/elixir-cloud-aai/TEStribute/dev)](https://coveralls.io/github/elixir-cloud-aai/TEStribute)
 
 Task distribution for GA4GH TES instances.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,11 +16,13 @@ clickclick==1.2.2
 connexion==2.3.0
 constantly==15.1.0
 coverage==5.0.3
+coveralls==1.11.1
 crochet==1.10.0
 cryptography==2.7
 cssselect==1.0.3
 decorator==4.4.0
 dicttoxml==1.7.4
+docopt==0.6.2
 docutils==0.15.2
 drs-client==0.2.0
 entrypoints==0.3


### PR DESCRIPTION
- add calls to calculate test coverage (`coverage`) and the coverage update for the badge (`coveralls`)
- add dependencies to `requirements.txt`
- add markdown for coverage badge to `README.md`