### PR TITLE
fix: add swagger UI dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ numpy==1.23.1
 pytest==7.1.2
 PyJWT>=1.6.4
 setuptools==44.0.0
+swagger-ui-bundle==0.0.9
 tes_client==0.2.1
 types-PyYAML==6.0.11
 types-requests==2.28.5


### PR DESCRIPTION
Connexion from 2.0.1 version onward don't have swagger-ui, currently using `(connexion==2.14.0)`. so need to add swagger-ui explicitly.
Added `swagger-ui-bundle==0.0.9 ` in requirements.txt.